### PR TITLE
fix: prevent docker_pull wait error loop

### DIFF
--- a/aliyun_clear.sh
+++ b/aliyun_clear.sh
@@ -725,10 +725,14 @@ docker_pull() {
     repo_tag="$1"
     mirrors="$(curl --insecure -fsSL https://ddsrem.com/xiaoya/all_in_one.sh | awk '/mirrors=\(/,/\)/' | sed -n 's/^[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p')"
     mirrors="$(
+        mirror_pids=""
         for line in $mirrors; do
             curl -s -o /dev/null -m 4 -w '%{time_total} '$line'\n' --head --request GET "$line" &
+            mirror_pids="$mirror_pids $!"
         done
-        wait
+        for mirror_pid in $mirror_pids; do
+            wait "$mirror_pid"
+        done
     )"
     mirrors="$(echo "$mirrors" | sort -n | awk '{print $2}')"
     mirrors="$(echo "$cust_docker_server"; echo "$mirrors")"


### PR DESCRIPTION
## 问题

`docker_pull()` 在命令替换中使用无参数 `wait`。脚本同时通过 `start_push_proc` 保持一个长期后台任务；在当前镜像的 Bash 5.3.3 中，命令替换子 shell 会尝试等待这个不属于自己的 PID，并陷入高速错误循环：

```text
wait: pid ... is not a child of this shell
```

实际故障中，该循环在约 68 分钟内生成了 17.1 GB Docker 日志。

## 修复

- 启动镜像源测速 `curl` 时记录本批进程的 PID
- 只逐个等待这些 PID，不再使用无参数 `wait`
- 保留原有并发测速和输出收集行为

Fixes #21

## 验证

- `bash -n aliyun_clear.sh`
- `sh -n aliyun_clear.sh`
- `git diff --check`
- 使用仓库 Dockerfile 完整构建镜像成功
- 从构建镜像中提取实际 `docker_pull()`，在 Bash 5.3.3 环境中保留父后台任务并模拟两个并发测速进程：
  - 修复前：2 秒产生 388129 行、20766704 字节 stderr，进程超时
  - 修复后：状态码 0、stderr 0 字节、两个测速进程均完成
